### PR TITLE
Removed deprecated kernel target

### DIFF
--- a/doc/1-cross-tools/1-kernel_headers
+++ b/doc/1-cross-tools/1-kernel_headers
@@ -7,10 +7,7 @@ patch -Np1 -i ../patches/kernel/include-uapi-linux-swab-Fix-potentially-missing-
 # Clean sources
 make mrproper
 
-# Build Headers
-make ARCH=${OML_ARCH} headers_check
-
-# Install
+# Build and install headers
 make ARCH=${OML_ARCH} headers
 mkdir -pv /cross-tools/${OML_TARGET}/include
 


### PR DESCRIPTION
headers_check is a deprecated feature and is advised to be removed from scripts.