### PR TITLE
Removed a patch after chroot and fixed documentation

### DIFF
--- a/doc/1-cross-tools/6-file
+++ b/doc/1-cross-tools/6-file
@@ -16,7 +16,9 @@ AS="${OML_TARGET}-as"          \
 RANLIB="${OML_TARGET}-ranlib"  \
 LD="${OML_TARGET}-ld"          \
 STRIP="${OML_TARGET}-strip"    \
-./configure --prefix=/cross-tools --disable-libseccomp
+./configure --host=$OML_TARGET \
+--prefix=/cross-tools \
+--disable-libseccomp
 
 # Build and install
 make && make install

--- a/doc/3-chroot/023-GCC
+++ b/doc/3-chroot/023-GCC
@@ -7,7 +7,6 @@ mv -v isl-0.23 isl
 
 # Apply patches from Alpine Linux
 for p in 0001-posix_memalign \
-  0002-gcc-poison-system-directories \
   0003-Turn-on-Wl-z-relro-z-now-by-default  \
   0004-Turn-on-D_FORTIFY_SOURCE-2-by-default-for-C-C-ObjC-O \
   0006-Enable-Wformat-and-Wformat-security-by-default \


### PR DESCRIPTION
As far as I know `gcc-posion-system-directories.patch` warns you when using system directories while cross compiling which is great.
However, this isn't an issue after chrooting as the system should be independent at that point.
Also fixed a problem with the documentation when cross compiling `file-5.40`.