### PR TITLE
Removed unnecessary seds of lib64 to lib

### DIFF
--- a/doc/1-cross-tools/5-GCC-final
+++ b/doc/1-cross-tools/5-GCC-final
@@ -77,14 +77,6 @@ do
 #  patch -Np1 -i ../patches/gcc-clear/$p.patch
 done
 
-# For 64-bit systems, fix a file so GCC installs libraries in 'lib' and not 'lib64'
-case $(uname -m) in
-  x86_64)
-    sed -e '/m64=/s/lib64/lib/' \
-        -i.orig gcc/config/i386/t-linux64
- ;;
-esac
-
 # Build in a dedicated build directory
 mkdir build && cd  build
 

--- a/doc/3-chroot/023-GCC
+++ b/doc/3-chroot/023-GCC
@@ -46,10 +46,6 @@ do
   patch -Np1 -i ../patches/gcc-alpine/$p.patch
 done
 
-# Make sure GCC installs libraries in /usr/lib and not /usr/lib64
-sed -e '/m64=/s/lib64/lib/' \
-    -i.orig gcc/config/i386/t-linux64
-
 # Build in a dedicated directory
 mkdir -v build && cd build
 


### PR DESCRIPTION
These should be covered in the patch `gcc-alpine/0024-use-pure-64-bit-configuration-where-appropriate`.